### PR TITLE
70 create web socket structure

### DIFF
--- a/models/database/repository/implementation/mongoose4/measure-repository.ts
+++ b/models/database/repository/implementation/mongoose4/measure-repository.ts
@@ -123,6 +123,19 @@ export class MeasureRepository implements IMeasureRepository {
 
     findAll(): Promise<IMeasure[]> {
         return MeasureModel.find()
+        .sort({date: 1})
+        .populate({path:'sensor', populate: {
+            path: 'type'
+        }})
+        .exec()
+        .then(toObject)
+        .then(normalizeFiledNames);
+    }
+
+    findAllDistinct(): Promise<IMeasure[]> {
+        return MeasureModel.find()
+        .sort({date: -1})
+        .distinct('sensor')
         .populate({path:'sensor', populate: {
             path: 'type'
         }})

--- a/models/database/repository/shared/measure-repository.ts
+++ b/models/database/repository/shared/measure-repository.ts
@@ -1,9 +1,12 @@
 import { IRepository } from "./repository";
 import { IMeasure } from "../../../interface/measure";
 import { ISensor } from "../../../interface/sensor";
-import { IEnvironment } from "../../../interface/environment";
 
 export interface IMeasureRepository extends IRepository<IMeasure> {
+
+    findLastsBySensorIds(sensorIds: string[], gte?: Date, lte?: Date): Promise<IMeasure[]>;
+    findLastBySensorId(sensorId: string, gte?: Date, lte?: Date): Promise<null | IMeasure>;
+
     findAllByTypeIds(sensorTypeIds: string[], sortBy?: string, gte?: Date, lte?: Date): Promise<null | IMeasure[]>;
     findAllByTypeId(sensorTypeId: string, sortBy?: string, gte?: Date, lte?: Date): Promise<null | IMeasure[]>;
 

--- a/models/database/repository/shared/measure-repository.ts
+++ b/models/database/repository/shared/measure-repository.ts
@@ -4,8 +4,8 @@ import { ISensor } from "../../../interface/sensor";
 
 export interface IMeasureRepository extends IRepository<IMeasure> {
 
-    findLastsBySensorIds(sensorIds: string[], gte?: Date, lte?: Date): Promise<IMeasure[]>;
-    findLastBySensorId(sensorId: string, gte?: Date, lte?: Date): Promise<null | IMeasure>;
+    findLastsBySensorIds(sensorIds: string[]): Promise<IMeasure[]>;
+    findLastBySensorId(sensorId: string): Promise<null | IMeasure>;
 
     findAllByTypeIds(sensorTypeIds: string[], sortBy?: string, gte?: Date, lte?: Date): Promise<null | IMeasure[]>;
     findAllByTypeId(sensorTypeId: string, sortBy?: string, gte?: Date, lte?: Date): Promise<null | IMeasure[]>;

--- a/models/database/repository/shared/pump-historical-repository.ts
+++ b/models/database/repository/shared/pump-historical-repository.ts
@@ -4,8 +4,8 @@ import { IPump } from "../../../interface/pump";
 
 export interface IPumpHistoricalRepository extends IRepository<IPumpHistorical> {
 
-    findLastsByPumpIds(pumpIds: string[], gte?: Date, lte?: Date): Promise<IPumpHistorical[]>;
-    findLastByPumpId(pumpId: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical>;
+    findLastsByPumpIds(pumpIds: string[]): Promise<IPumpHistorical[]>;
+    findLastByPumpId(pumpId: string): Promise<null | IPumpHistorical>;
 
     findAllByPumpId(pumpId: string, sortBy: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical[]>;
     findAllByPump(pump: IPump, sortBy?: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical[]>;

--- a/models/database/repository/shared/pump-historical-repository.ts
+++ b/models/database/repository/shared/pump-historical-repository.ts
@@ -1,7 +1,6 @@
 import { IRepository } from "./repository";
 import { IPumpHistorical } from "../../../interface/pump-historical";
 import { IPump } from "../../../interface/pump";
-import { IEnvironment } from "../../../interface/environment";
 
 export interface IPumpHistoricalRepository extends IRepository<IPumpHistorical> {
 

--- a/models/database/repository/shared/pump-historical-repository.ts
+++ b/models/database/repository/shared/pump-historical-repository.ts
@@ -4,6 +4,10 @@ import { IPump } from "../../../interface/pump";
 import { IEnvironment } from "../../../interface/environment";
 
 export interface IPumpHistoricalRepository extends IRepository<IPumpHistorical> {
+
+    findLastsByPumpIds(pumpIds: string[], gte?: Date, lte?: Date): Promise<IPumpHistorical[]>;
+    findLastByPumpId(pumpId: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical>;
+
     findAllByPumpId(pumpId: string, sortBy: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical[]>;
     findAllByPump(pump: IPump, sortBy?: string, gte?: Date, lte?: Date): Promise<null | IPumpHistorical[]>;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,7 @@
     "@types/node": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
-      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==",
-      "dev": true
+      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ=="
     },
     "@types/restify": {
       "version": "5.0.9",
@@ -108,6 +107,14 @@
         "@types/verror": "*"
       }
     },
+    "@types/socket.io": {
+      "version": "1.4.38",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.38.tgz",
+      "integrity": "sha512-+f49CywK6w2RNDzcug7iUVZoC0262Wr6XrGg0yunW+wFBG8RXC8hiQm94HV1I3H0/8bEodGSjDOxd4i2yhFbwA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/spdy": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
@@ -122,6 +129,25 @@
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.3.tgz",
       "integrity": "sha512-7Jz0MPsW2pWg5dJfEp9nJYI0RDCYfgjg2wIo5HfQ8vOJvUq0/BxT7Mv2wNQvkKBmV9uT++6KF3reMnLmh/0HrA==",
       "dev": true
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "asn1": {
       "version": "0.2.4",
@@ -142,10 +168,30 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -155,6 +201,19 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -197,6 +256,11 @@
         "safe-json-stringify": "~1"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -232,10 +296,30 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -279,6 +363,14 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -316,6 +408,49 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "engine.io": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary2": "~1.0.2"
       }
     },
     "es6-promise": {
@@ -398,6 +533,26 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -440,6 +595,11 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -520,6 +680,19 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+    },
+    "mime-types": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "requires": {
+        "mime-db": "~1.36.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -736,6 +909,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -747,6 +925,22 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
       }
     },
     "path-is-absolute": {
@@ -939,6 +1133,62 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "socket.io": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "requires": {
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.1.1",
+        "socket.io-parser": "~3.2.0"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+    },
+    "socket.io-client": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.2.0",
+        "to-array": "0.1.4"
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
     "spdy": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
@@ -1024,6 +1274,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -1041,6 +1296,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1105,10 +1365,30 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1089,6 +1089,19 @@
         }
       }
     },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "rxjs-compat": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.3.3.tgz",
+      "integrity": "sha512-caGN7ixiabHpOofginKEquuHk7GgaCrC7UpUQ9ZqGp80tMc68msadOeP/2AKy2R4YJsT1+TX5GZCtxO82qWkyA=="
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -1278,6 +1291,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "mongoose": "^4.13.17",
     "restify": "^7.2.1",
     "restify-errors": "^4.3.0",
+    "rxjs": "^6.3.3",
+    "rxjs-compat": "^6.3.3",
     "socket.io": "^2.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/socket.io": "^1.4.38",
     "mongoose": "^4.13.17",
     "restify": "^7.2.1",
-    "restify-errors": "^4.3.0"
+    "restify-errors": "^4.3.0",
+    "socket.io": "^2.1.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",

--- a/routes/helpers.ts
+++ b/routes/helpers.ts
@@ -21,8 +21,9 @@ export function checkQuery(query: string[], querySended: object)
     return element === undefined? Promise.resolve() : Promise.reject(error);
 }
 
-export function handleJsonData(data: any, res: Response, next: Next, status?: number): void {
+export function handleJsonData<T>(data: T, res: Response, next: Next, status?: number): Promise<T> {
     dataHandler.handleJson(data, res, next, status);
+    return Promise.resolve(data);
 }
 
 export function handleErrors(err: Error, next: Next): void {

--- a/routes/measures.ts
+++ b/routes/measures.ts
@@ -4,8 +4,10 @@ import * as measureValidator from "../validation/measure";
 import * as sensorValidator from "../validation/sensor";
 import { handleJsonData, handleErrors, checkQuery } from "../routes/helpers";
 import { IMeasure } from "../models/interface/measure";
+import { SocketIOService } from "../services/socket-io-service";
 
-export function routes(server: restify.Server, mainPath: string = ''): void {
+export function routes(server: restify.Server, mainPath: string = '',
+    socketIOService: SocketIOService): void {
 
     const commonQuery: string[] = ['gte', 'lte', 'sortBy'];
 
@@ -69,6 +71,10 @@ export function routes(server: restify.Server, mainPath: string = ''): void {
     server.post(mainPath, (req, res, next)=>{
         measureValidator.validate(req.body)
         .then(measure => Middleware.addMeasure(measure))
+        .then(measure => {
+            socketIOService.emitLastMeasure(measure);
+            return measure;
+        })
         .then(measure => handleJsonData(measure, res, next, 201))
         .catch(err => handleErrors(err, next));
     });

--- a/routes/measures.ts
+++ b/routes/measures.ts
@@ -7,7 +7,7 @@ import { IMeasure } from "../models/interface/measure";
 import { SocketIOService } from "../services/socket-io-service";
 
 export function routes(server: restify.Server, mainPath: string = '',
-socketIOService: SocketIOService): void {
+sIOService: SocketIOService): void {
 
     const commonQuery: string[] = ['gte', 'lte', 'sortBy'];
 
@@ -69,10 +69,13 @@ socketIOService: SocketIOService): void {
     });
 
     server.post(mainPath, (req, res, next) => {
+        if (!req.body.date) {
+            req.body.date = new Date();
+        }
         measureValidator.validate(req.body)
         .then(measure => Middleware.addMeasure(measure))
         .then(measure => handleJsonData<IMeasure>(measure, res, next, 201))
-        .then(measure => socketIOService.emitLastMeasure(measure))
+        .then(measure => sIOService.sensorsSIOService.emitLastMeasure(measure))
         .catch(err => handleErrors(err, next));
     });
 

--- a/routes/measures.ts
+++ b/routes/measures.ts
@@ -7,7 +7,7 @@ import { IMeasure } from "../models/interface/measure";
 import { SocketIOService } from "../services/socket-io-service";
 
 export function routes(server: restify.Server, mainPath: string = '',
-    socketIOService: SocketIOService): void {
+socketIOService: SocketIOService): void {
 
     const commonQuery: string[] = ['gte', 'lte', 'sortBy'];
 
@@ -68,14 +68,11 @@ export function routes(server: restify.Server, mainPath: string = '',
         .catch(err => handleErrors(err, next));
     });
 
-    server.post(mainPath, (req, res, next)=>{
+    server.post(mainPath, (req, res, next) => {
         measureValidator.validate(req.body)
         .then(measure => Middleware.addMeasure(measure))
-        .then(measure => {
-            socketIOService.emitLastMeasure(measure);
-            return measure;
-        })
-        .then(measure => handleJsonData(measure, res, next, 201))
+        .then(measure => handleJsonData<IMeasure>(measure, res, next, 201))
+        .then(measure => socketIOService.emitLastMeasure(measure))
         .catch(err => handleErrors(err, next));
     });
 

--- a/routes/pumps-historicals.ts
+++ b/routes/pumps-historicals.ts
@@ -7,7 +7,7 @@ import { IPumpHistorical } from "../models/interface/pump-historical";
 import { SocketIOService } from "../services/socket-io-service";
 
 export function routes(server: restify.Server, mainPath: string = '',
-socketIOService: SocketIOService): void {
+sIOService: SocketIOService): void {
 
     const commonQuery: string[] = ['gte', 'lte', 'sortBy'];
 
@@ -69,10 +69,14 @@ socketIOService: SocketIOService): void {
     });
 
     server.post(mainPath, (req, res, next) => {
+        if (!req.body.date) {
+            req.body.date = new Date();
+        }
         pumpHistoricalValidator.validate(req.body)
         .then(pumpHistorical => Middleware.addPumpHistorical(pumpHistorical))
         .then(pumpHistorical => handleJsonData(pumpHistorical, res, next, 201))
-        .then(pumpHistorical => socketIOService.emitLastPumpHistorical(pumpHistorical))
+        .then(pumpHistorical => sIOService.pumpsSIOService
+            .emitLastPumpHistorical(pumpHistorical))
         .catch(err => handleErrors(err, next));
     });
 

--- a/routes/pumps-historicals.ts
+++ b/routes/pumps-historicals.ts
@@ -4,8 +4,10 @@ import * as pumpHistoricalValidator from "../validation/pump-historical";
 import * as pumpValidator from "../validation/pump";
 import { handleJsonData, handleErrors, checkQuery } from "./helpers";
 import { IPumpHistorical } from "../models/interface/pump-historical";
+import { SocketIOService } from "../services/socket-io-service";
 
-export function routes(server: restify.Server, mainPath: string = ''): void {
+export function routes(server: restify.Server, mainPath: string = '',
+socketIOService: SocketIOService): void {
 
     const commonQuery: string[] = ['gte', 'lte', 'sortBy'];
 
@@ -70,6 +72,7 @@ export function routes(server: restify.Server, mainPath: string = ''): void {
         pumpHistoricalValidator.validate(req.body)
         .then(pumpHistorical => Middleware.addPumpHistorical(pumpHistorical))
         .then(pumpHistorical => handleJsonData(pumpHistorical, res, next, 201))
+        .then(pumpHistorical => socketIOService.emitLastPumpHistorical(pumpHistorical))
         .catch(err => handleErrors(err, next));
     });
 

--- a/services/pumps-sio.service.ts
+++ b/services/pumps-sio.service.ts
@@ -1,0 +1,74 @@
+import { Subscriber } from "rxjs";
+
+import { IPumpHistorical } from "../models/interface/pump-historical";
+
+import { pumpHistoricalRepository } from "../models/database/repository/implementation/mongoose4/pump-historical-repository";
+import { SIOService } from "./sio-service";
+
+const enum NamespaceNames {
+    LastPumpHistoricals = '/pumps/last-historicals'
+};
+
+const enum EventNames {
+    LastHistoricals = 'last-historicals',
+    GetLastHistoricals = 'get-last-historicals'
+};
+
+export class PumpsSIOService implements SIOService {
+
+    private io: SocketIO.Server;
+    private lastPumpHistoricals$: Subscriber<IPumpHistorical>;
+
+    constructor(io: SocketIO.Server) {
+        this.io = io;
+        this.setUpSubscribers();
+    }
+
+    emitLastPumpHistorical(pumpHistorical: IPumpHistorical): Promise<IPumpHistorical> {
+        this.lastPumpHistoricals$.next(pumpHistorical);
+        return Promise.resolve(pumpHistorical);
+    }
+
+    listen() {
+        this.listenLastPumpHistoricals();
+    }
+
+    private setUpSubscribers() {
+        // Last pump historicals subscriber
+        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
+        this.lastPumpHistoricals$ = new Subscriber(
+            o => {
+                namespace.emit(EventNames.LastHistoricals, [o]);
+            }
+        );
+        // Other subscriber here
+    }
+
+    private listenLastPumpHistoricals() {
+        // Create the namespace
+        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
+        // Listen any new connection for that namespace
+        namespace.on('connection', socket =>  {
+            // Set the events here.
+
+            // 'EventNames.GetLastHistoricals' event gets all the
+            // last pump historicals explicitycally
+            socket.on(EventNames.GetLastHistoricals, data => {
+                // if there is any pump id,
+                // it gets all the pump id's from the system
+                return new Promise(resolve => {
+                    let pumpIds: string[] = data.pumpIds || [];
+                    if (!Array.isArray(pumpIds)) {
+                        pumpIds = [];
+                    }
+                    resolve(pumpHistoricalRepository
+                    .findLastsByPumpIds(pumpIds));
+                })
+                .then(historicalPumps => {
+                    socket.emit(EventNames.LastHistoricals, historicalPumps);
+                });
+            });
+
+        });
+    }
+}

--- a/services/sensors-sio.service.ts
+++ b/services/sensors-sio.service.ts
@@ -1,0 +1,73 @@
+import { Subscriber } from "rxjs";
+
+import { measureRepository } from "../models/database/repository/implementation/mongoose4/measure-repository";
+import { SIOService } from "./sio-service";
+import { IMeasure } from "../models/interface/measure";
+
+const enum NamespaceNames {
+    LastMeasures = '/sensors/last-measures'
+};
+
+const enum EventNames {
+    LastMeasures = 'last-measures',
+    GetLastMeasures = 'get-last-measures'
+};
+
+export class SensorsSIOService implements SIOService {
+
+    private io: SocketIO.Server;
+    private lastMeasure$: Subscriber<IMeasure>;
+
+    constructor(io: SocketIO.Server) {
+        this.io = io;
+        this.setUpSubscribers();
+    }
+
+    emitLastMeasure(measure: IMeasure): Promise<IMeasure> {
+        this.lastMeasure$.next(measure);
+        return Promise.resolve(measure);
+    }
+
+    listen() {
+        this.listenLastMeasures();
+    }
+
+    private setUpSubscribers() {
+        // Last pump historicals subscriber
+        const namespace = this.io.of(NamespaceNames.LastMeasures);
+        this.lastMeasure$ = new Subscriber(
+            o => {
+                namespace.emit(EventNames.LastMeasures, [o]);
+            }
+        );
+        // Other subscriber here
+    }
+
+    private listenLastMeasures() {
+        // Create the namespace
+        const namespace = this.io.of(NamespaceNames.LastMeasures);
+        // Listen any new connection for that namespace
+        namespace.on('connection', socket =>  {
+            // Set the events here.
+
+            // 'EventNames.GetLastMeasures' event gets all the
+            // last measures explicitycally
+            socket.on(EventNames.GetLastMeasures, data => {
+                // if there is any sensor id,
+                // it gets all the sensor id's from the system
+                return new Promise(resolve => {
+                    let sensorIds: string[] = data.sensorIds ||  [];
+                    if (!Array.isArray(sensorIds)) {
+                        sensorIds = [];
+                    }
+                    resolve(measureRepository
+                    .findLastsBySensorIds(sensorIds));
+                })
+                .then(measures => {
+                    socket.emit(EventNames.LastMeasures, measures);
+                });
+            });
+
+        });
+    }
+}

--- a/services/sio-service.ts
+++ b/services/sio-service.ts
@@ -1,0 +1,3 @@
+export interface SIOService {
+    listen();
+}

--- a/services/socket-io-service.ts
+++ b/services/socket-io-service.ts
@@ -1,130 +1,23 @@
 import SocketIO = require("socket.io");
-import { IMeasure } from "../models/interface/measure";
-import { Subscriber } from "rxjs";
-import { measureRepository } from "../models/database/repository/implementation/mongoose4/measure-repository";
 import { Server } from "http";
-import { IPumpHistorical } from "../models/interface/pump-historical";
-import { pumpHistoricalRepository } from "../models/database/repository/implementation/mongoose4/pump-historical-repository";
-import { sensorRepository } from "../models/database/repository/implementation/mongoose4/sensor-repository";
-import { pumpRepository } from "../models/database/repository/implementation/mongoose4/pump-repository";
-
-const enum NamespaceNames {
-    LastMeasures = '/measures/last-measures',
-    LastPumpHistoricals = '/pumps/last-historicals'
-};
+import { PumpsSIOService } from "./pumps-sio.service";
+import { SensorsSIOService } from "./sensors-sio.service";
 
 export class SocketIOService {
 
+    pumpsSIOService: PumpsSIOService;
+    sensorsSIOService: SensorsSIOService;
+
     private io: SocketIO.Server;
-    private lastMeasure$: Subscriber<IMeasure>;
-    private lastPumpHistoricals$: Subscriber<IPumpHistorical>;
 
     constructor(server: Server) {
         this.io = SocketIO(server);
-        this.setUpMeasureSubscriber();
-        this.setUpPumpHistoricalsSubscriber();
-    }
-
-    emitLastMeasure(measure: IMeasure): Promise<IMeasure> {
-        this.lastMeasure$.next(measure);
-        return Promise.resolve(measure);
-    }
-
-    emitLastPumpHistorical(pumpHistorical: IPumpHistorical): Promise<IPumpHistorical> {
-        this.lastPumpHistoricals$.next(pumpHistorical);
-        return Promise.resolve(pumpHistorical);
+        this.pumpsSIOService = new PumpsSIOService(this.io);
+        this.sensorsSIOService = new SensorsSIOService(this.io);
     }
 
     listen() {
-        this.listenLastMeasures();
-        this.listenLastPumpHistoricals();
-    }
-
-    private listenLastMeasures() {
-        const eventName = 'last-measures';
-        // Create the namespace
-        const namespace = this.io.of(NamespaceNames.LastMeasures);
-        // Listen any new connection for that namespace
-        namespace.on('connection', socket =>  {
-
-            // 'get' event gets all the last measures explicitycally
-            socket.on('get', data => {
-
-                // if there is any sensor id
-                // it gets all the sensor id's from the system
-                return Promise.resolve(data.sensorIds)
-                .then(sensorIds => {
-                    if (!Array.isArray(sensorIds) || !sensorIds.length) {
-                        return sensorRepository.findAll()
-                        .then(sensors => sensors.map(s => s.id));
-                    }
-                    return sensorIds;
-                })
-                .then(sensorIds => {
-                    return measureRepository
-                    .findLastsBySensorIds(sensorIds, data.gte, data.lte);
-                })
-                .then(measures => {
-                    socket.emit(eventName, measures);
-                });
-            });
-        });
-    }
-
-    private listenLastPumpHistoricals() {
-        const eventName = 'last-historicals';
-        // Create the namespace
-        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
-        // Listen any new connection for that namespace
-        namespace.on('connection', socket =>  {
-
-            // 'get' event gets all the last measures explicitycally
-            socket.on('get', data => {
-
-                // if there is any sensor id
-                // it gets all the sensor id's from the system
-                return Promise.resolve(data.pumpIds)
-                .then(pumpIds => {
-                    if (!Array.isArray(pumpIds) || !pumpIds.length) {
-                        return pumpRepository.findAll()
-                        .then(pumps => pumps.map(p => p.id));
-                    }
-                    return pumpIds;
-                })
-                .then(pumpIds => {
-                    return pumpHistoricalRepository
-                    .findLastsByPumpIds(pumpIds, data.gte, data.lte);
-                })
-                .then(historicalPumps => {
-                    socket.emit(eventName, historicalPumps);
-                });
-            });
-        });
-    }
-
-    private setUpMeasureSubscriber() {
-        if (!this.io) {
-            return;
-        }
-        const eventName = 'last-measures';
-        const namespace = this.io.of(NamespaceNames.LastMeasures);
-        this.lastMeasure$ = new Subscriber(
-            o => {
-                namespace.emit(eventName, [o]);
-            }
-        );
-    }
-
-    private setUpPumpHistoricalsSubscriber() {
-        if (!this.io) {
-            return;
-        }
-        const eventName = 'last-historicals';
-        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
-        this.lastPumpHistoricals$ = new Subscriber(
-            o => {
-                namespace.emit(eventName, [o]);
-            }
-        );
+        this.pumpsSIOService.listen();
+        this.sensorsSIOService.listen();
     }
 }

--- a/services/socket-io-service.ts
+++ b/services/socket-io-service.ts
@@ -72,7 +72,7 @@ export class SocketIOService {
     }
 
     private listenLastPumpHistoricals() {
-        const eventName = 'last-pump-historicals';
+        const eventName = 'last-historicals';
         // Create the namespace
         const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
         // Listen any new connection for that namespace
@@ -119,7 +119,7 @@ export class SocketIOService {
         if (!this.io) {
             return;
         }
-        const eventName = 'last-pump-historicals';
+        const eventName = 'last-historicals';
         const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
         this.lastPumpHistoricals$ = new Subscriber(
             o => {

--- a/services/socket-io-service.ts
+++ b/services/socket-io-service.ts
@@ -3,42 +3,100 @@ import { IMeasure } from "../models/interface/measure";
 import { Subscriber } from "rxjs";
 import { measureRepository } from "../models/database/repository/implementation/mongoose4/measure-repository";
 import { Server } from "http";
+import { IPumpHistorical } from "../models/interface/pump-historical";
+import { pumpHistoricalRepository } from "../models/database/repository/implementation/mongoose4/pump-historical-repository";
+import { sensorRepository } from "../models/database/repository/implementation/mongoose4/sensor-repository";
+import { pumpRepository } from "../models/database/repository/implementation/mongoose4/pump-repository";
 
-const enum NamespaceStr {
-    LastMeasures = '/measures/last-measures'
+const enum NamespaceNames {
+    LastMeasures = '/measures/last-measures',
+    LastPumpHistoricals = '/pumps/last-historicals'
 };
 
 export class SocketIOService {
 
     private io: SocketIO.Server;
     private lastMeasure$: Subscriber<IMeasure>;
+    private lastPumpHistoricals$: Subscriber<IPumpHistorical>;
 
     constructor(server: Server) {
         this.io = SocketIO(server);
         this.setUpMeasureSubscriber();
+        this.setUpPumpHistoricalsSubscriber();
     }
 
-    emitLastMeasure(measure: IMeasure) {
+    emitLastMeasure(measure: IMeasure): Promise<IMeasure> {
         this.lastMeasure$.next(measure);
+        return Promise.resolve(measure);
+    }
+
+    emitLastPumpHistorical(pumpHistorical: IPumpHistorical): Promise<IPumpHistorical> {
+        this.lastPumpHistoricals$.next(pumpHistorical);
+        return Promise.resolve(pumpHistorical);
     }
 
     listen() {
         this.listenLastMeasures();
+        this.listenLastPumpHistoricals();
     }
 
     private listenLastMeasures() {
+        const eventName = 'last-measures';
         // Create the namespace
-        const namespace = this.io.of(NamespaceStr.LastMeasures);
+        const namespace = this.io.of(NamespaceNames.LastMeasures);
         // Listen any new connection for that namespace
         namespace.on('connection', socket =>  {
 
             // 'get' event gets all the last measures explicitycally
             socket.on('get', data => {
-                measureRepository.findAll()
-                .then(measures => {
-                    if (measures.length) {
-                        socket.emit('last-measures', measures[0]);
+
+                // if there is any sensor id
+                // it gets all the sensor id's from the system
+                return Promise.resolve(data.sensorIds)
+                .then(sensorIds => {
+                    if (!Array.isArray(sensorIds) || !sensorIds.length) {
+                        return sensorRepository.findAll()
+                        .then(sensors => sensors.map(s => s.id));
                     }
+                    return sensorIds;
+                })
+                .then(sensorIds => {
+                    return measureRepository
+                    .findLastsBySensorIds(sensorIds, data.gte, data.lte);
+                })
+                .then(measures => {
+                    socket.emit(eventName, measures);
+                });
+            });
+        });
+    }
+
+    private listenLastPumpHistoricals() {
+        const eventName = 'last-pump-historicals';
+        // Create the namespace
+        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
+        // Listen any new connection for that namespace
+        namespace.on('connection', socket =>  {
+
+            // 'get' event gets all the last measures explicitycally
+            socket.on('get', data => {
+
+                // if there is any sensor id
+                // it gets all the sensor id's from the system
+                return Promise.resolve(data.pumpIds)
+                .then(pumpIds => {
+                    if (!Array.isArray(pumpIds) || !pumpIds.length) {
+                        return pumpRepository.findAll()
+                        .then(pumps => pumps.map(p => p.id));
+                    }
+                    return pumpIds;
+                })
+                .then(pumpIds => {
+                    return pumpHistoricalRepository
+                    .findLastsByPumpIds(pumpIds, data.gte, data.lte);
+                })
+                .then(historicalPumps => {
+                    socket.emit(eventName, historicalPumps);
                 });
             });
         });
@@ -48,11 +106,24 @@ export class SocketIOService {
         if (!this.io) {
             return;
         }
-        const namespace = this.io.of(NamespaceStr.LastMeasures);
+        const eventName = 'last-measures';
+        const namespace = this.io.of(NamespaceNames.LastMeasures);
         this.lastMeasure$ = new Subscriber(
-            (lastMeasure: IMeasure) => {
-                // Send the 'measures' to all sockets of the namespace
-                namespace.emit('last-measures', lastMeasure);
+            o => {
+                namespace.emit(eventName, [o]);
+            }
+        );
+    }
+
+    private setUpPumpHistoricalsSubscriber() {
+        if (!this.io) {
+            return;
+        }
+        const eventName = 'last-pump-historicals';
+        const namespace = this.io.of(NamespaceNames.LastPumpHistoricals);
+        this.lastPumpHistoricals$ = new Subscriber(
+            o => {
+                namespace.emit(eventName, [o]);
             }
         );
     }

--- a/services/socket-io-service.ts
+++ b/services/socket-io-service.ts
@@ -1,0 +1,66 @@
+import SocketIO = require("socket.io");
+import { IMeasure } from "../models/interface/measure";
+import { Subscriber, Subject } from "rxjs";
+import { measureRepository } from "../models/database/repository/implementation/mongoose4/measure-repository";
+import { Server } from "http";
+
+export class SocketIOService {
+
+    private io: SocketIO.Server;
+    private lastMeasure$: Subject<IMeasure>;
+
+    constructor(server: Server) {
+        this.io = SocketIO(server);
+        this.lastMeasure$ = new Subject();
+    }
+
+    emitLastMeasure(measure: IMeasure) {
+        this.lastMeasure$.next(measure);
+    }
+
+    listen() {
+        const namespaceStr = '/measures/last-measures';
+        const namespace = this.io.of(namespaceStr);
+        namespace.on('connection', socket =>  {
+
+            socket.on('subscribe', data => {
+                const roomName = data.room ? data.room : '';
+
+                if (roomName === 'all-room') {
+                    socket.join(roomName);
+                    // Create an observer
+                    const observer = new Subscriber(
+                        (lastMeasure: IMeasure) => {
+                            namespace.to(roomName)
+                                .emit('last-measures', lastMeasure);
+                            console.log('emitting new measure in ' + roomName);
+                        }
+                    );
+                    // Subscribe the observer into the lastMeasure$
+                    const susbscrition = this.lastMeasure$.subscribe(observer);
+                    // Find all the 'last measures' and emit them
+                    measureRepository.findAll()
+                    .then(measures => {
+                        if (measures.length) {
+                            console.log('New connection...');
+                            this.emitLastMeasure(measures[0]);
+                        }
+                    });
+
+                    // Unsubscribe the observer in case of disconnection
+                    socket.on('disconnect', reason => {
+                        console.log('socket disconnected');
+                        susbscrition.unsubscribe();
+                    });
+                }
+            });
+
+            socket.on('unsubscribe', data =>
+            {
+                if(data.room) {
+                    socket.leave(data.room);
+                }
+            });
+        });
+    }
+}

--- a/services/socket-io-service.ts
+++ b/services/socket-io-service.ts
@@ -1,17 +1,21 @@
 import SocketIO = require("socket.io");
 import { IMeasure } from "../models/interface/measure";
-import { Subscriber, Subject } from "rxjs";
+import { Subscriber } from "rxjs";
 import { measureRepository } from "../models/database/repository/implementation/mongoose4/measure-repository";
 import { Server } from "http";
+
+const enum NamespaceStr {
+    LastMeasures = '/measures/last-measures'
+};
 
 export class SocketIOService {
 
     private io: SocketIO.Server;
-    private lastMeasure$: Subject<IMeasure>;
+    private lastMeasure$: Subscriber<IMeasure>;
 
     constructor(server: Server) {
         this.io = SocketIO(server);
-        this.lastMeasure$ = new Subject();
+        this.setUpMeasureSubscriber();
     }
 
     emitLastMeasure(measure: IMeasure) {
@@ -19,48 +23,37 @@ export class SocketIOService {
     }
 
     listen() {
-        const namespaceStr = '/measures/last-measures';
-        const namespace = this.io.of(namespaceStr);
+        this.listenLastMeasures();
+    }
+
+    private listenLastMeasures() {
+        // Create the namespace
+        const namespace = this.io.of(NamespaceStr.LastMeasures);
+        // Listen any new connection for that namespace
         namespace.on('connection', socket =>  {
 
-            socket.on('subscribe', data => {
-                const roomName = data.room ? data.room : '';
-
-                if (roomName === 'all-room') {
-                    socket.join(roomName);
-                    // Create an observer
-                    const observer = new Subscriber(
-                        (lastMeasure: IMeasure) => {
-                            namespace.to(roomName)
-                                .emit('last-measures', lastMeasure);
-                            console.log('emitting new measure in ' + roomName);
-                        }
-                    );
-                    // Subscribe the observer into the lastMeasure$
-                    const susbscrition = this.lastMeasure$.subscribe(observer);
-                    // Find all the 'last measures' and emit them
-                    measureRepository.findAll()
-                    .then(measures => {
-                        if (measures.length) {
-                            console.log('New connection...');
-                            this.emitLastMeasure(measures[0]);
-                        }
-                    });
-
-                    // Unsubscribe the observer in case of disconnection
-                    socket.on('disconnect', reason => {
-                        console.log('socket disconnected');
-                        susbscrition.unsubscribe();
-                    });
-                }
-            });
-
-            socket.on('unsubscribe', data =>
-            {
-                if(data.room) {
-                    socket.leave(data.room);
-                }
+            // 'get' event gets all the last measures explicitycally
+            socket.on('get', data => {
+                measureRepository.findAll()
+                .then(measures => {
+                    if (measures.length) {
+                        socket.emit('last-measures', measures[0]);
+                    }
+                });
             });
         });
+    }
+
+    private setUpMeasureSubscriber() {
+        if (!this.io) {
+            return;
+        }
+        const namespace = this.io.of(NamespaceStr.LastMeasures);
+        this.lastMeasure$ = new Subscriber(
+            (lastMeasure: IMeasure) => {
+                // Send the 'measures' to all sockets of the namespace
+                namespace.emit('last-measures', lastMeasure);
+            }
+        );
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import * as PumpsHistoricalsRoutes from "../routes/pumps-historicals";
 import { addErrorHandler } from "../routes/helpers";
 import { errorHandler as DataErrorHandler } from "../routes/helpers/data-error-handler";
 import { errorHandler as MongooseErrorHandler } from "../routes/helpers/mongoose-error-handler";
-import { socketService } from "../services/sockerio";
+import { SocketIOService } from "../services/socket-io-service";
 
 
 // Configure database
@@ -30,8 +30,9 @@ const server = restify.createServer({
 addErrorHandler(DataErrorHandler);
 addErrorHandler(MongooseErrorHandler);
 
-// const io: SocketIO.Server = SocketIO(server);
-
+// SocketIO Service setup and listening
+const socketIOService = new SocketIOService(server.server);
+socketIOService.listen();
 
 // Set server plugings
 server.use(restify.plugins.acceptParser(server.acceptable));
@@ -41,7 +42,7 @@ server.use(restify.plugins.bodyParser());
 // Set routes
 let apiVersion = Config.Server.VERSION.split('.');
 let apiRoute = '/api/v' + apiVersion[0];
-MeasuresRoutes.routes(server, apiRoute + '/measures');
+MeasuresRoutes.routes(server, apiRoute + '/measures', socketIOService);
 PumpsRoutes.routes(server, apiRoute + '/pumps');
 PumpsHistoricalsRoutes.routes(server, apiRoute + '/pump-historicals');
 EnvironmentsRoutes.routes(server, apiRoute + '/environments');

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ let apiVersion = Config.Server.VERSION.split('.');
 let apiRoute = '/api/v' + apiVersion[0];
 MeasuresRoutes.routes(server, apiRoute + '/measures', socketIOService);
 PumpsRoutes.routes(server, apiRoute + '/pumps');
-PumpsHistoricalsRoutes.routes(server, apiRoute + '/pump-historicals');
+PumpsHistoricalsRoutes.routes(server, apiRoute + '/pump-historicals', socketIOService);
 EnvironmentsRoutes.routes(server, apiRoute + '/environments');
 SensorsRoutes.routes(server, apiRoute + '/sensors');
 SensorTypesRoutes.routes(server, apiRoute + '/sensor-types');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import * as PumpsHistoricalsRoutes from "../routes/pumps-historicals";
 import { addErrorHandler } from "../routes/helpers";
 import { errorHandler as DataErrorHandler } from "../routes/helpers/data-error-handler";
 import { errorHandler as MongooseErrorHandler } from "../routes/helpers/mongoose-error-handler";
+import { socketService } from "../services/sockerio";
+
 
 // Configure database
 mongoose.Promise = Promise;
@@ -27,6 +29,9 @@ const server = restify.createServer({
 // Setup error handlers
 addErrorHandler(DataErrorHandler);
 addErrorHandler(MongooseErrorHandler);
+
+// const io: SocketIO.Server = SocketIO(server);
+
 
 // Set server plugings
 server.use(restify.plugins.acceptParser(server.acceptable));


### PR DESCRIPTION
Add socket.io for **measures** and **pump-historicals** to get the last record created by date in real time.

- Services created.
- Routes adapted.
- Measure and pump-historical repositories adapted and improved.

The socket.io API:

There are two namespaces with two events each:

- _/pumps/last-historicals_
    - _last-historicals_: Used by the backend to send the last pump-historicals
    - _get-last-historicals_: Used by the client to get the last pump-historicals by the object passed **{ pumpIds: [] }**
- _/sensors/last-measures_
    - _last-measures_: Used by the backend to send the last measures
    - _get-last-measures_: Used by the client to get the last measures by the object passed **{ sensorIds: [] }**
