### PR TITLE
Hotfixes/deploy also on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+dist
 *.js
 *.js.map

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "yarn compile && mocha --recursive --exit ./dist/test",
     "start": "node ./dist/src/index.js",
     "build": "yarn compile && ./scripts/build-docker-image.sh",
-    "deploy": "./scripts/deploy-docker-image.sh",
+    "deploy": "./scripts/deploy-dockerhub-image.sh; ./scripts/deploy-github-image.sh",
     "release": "./scripts/incr-version.sh release"
   },
   "author": "gabrielmdc",

--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -3,4 +3,4 @@
 echo "Running build..."
 PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
 VERSION=$(cut -d '.' -f1,2 <<< $PACKAGE_VERSION)
-docker build . -t gmdcwork/greenpi-backend:$VERSION
+docker build . -t greenpi-backend:$VERSION

--- a/scripts/deploy-docker-image.sh
+++ b/scripts/deploy-docker-image.sh
@@ -1,12 +1,3 @@
 #!/bin/bash
 
-if [[ -z $DOCKER_HUB || -z $DOCKER_HUB_KEY ]]; then
-    echo "ERROR: the environment variables 'DOCKER_HUB' and 'DOCKER_HUB_KEY' must be defined"
-    exit 1;
-fi
-PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
-VERSION=$(cut -d '.' -f1,2 <<< $PACKAGE_VERSION)
-echo "Docker login..."
-docker login -u $DOCKER_HUB -p $DOCKER_HUB_KEY &&
-echo "Pushing image..." &&
-docker push gmdcwork/greenpi-backend:$VERSION
+./deploy-github-image.sh

--- a/scripts/deploy-docker-image.sh
+++ b/scripts/deploy-docker-image.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./deploy-github-image.sh

--- a/scripts/deploy-dockerhub-image.sh
+++ b/scripts/deploy-dockerhub-image.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z $DOCKER_HUB || -z $DOCKER_HUB_KEY ]]; then
+    echo "ERROR: the environment variables 'DOCKER_HUB' and 'DOCKER_HUB_KEY' must be defined"
+    exit 1;
+fi
+PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+VERSION=$(cut -d '.' -f1,2 <<< $PACKAGE_VERSION)
+echo "Docker-Hub login..."
+docker login -u $DOCKER_HUB -p $DOCKER_HUB_KEY &&
+echo "Tagging..." &&
+docker tag greenpi-backend:$VERSION gmdcwork/greenpi-backend:$VERSION
+echo "Pushing image into Docker-Hub..." &&
+docker push gmdcwork/greenpi-backend:$VERSION

--- a/scripts/deploy-github-image.sh
+++ b/scripts/deploy-github-image.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ -z $GITHUB_REGISTRY_USER || -z $GITHUB_REGISTRY_TOKEN ]]; then
+    echo "ERROR: the environment variables 'GITHUB_REGISTRY_USER' and 'GITHUB_REGISTRY_TOKEN' must be defined"
+    exit 1;
+fi
+PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+VERSION=$(cut -d '.' -f1,2 <<< $PACKAGE_VERSION)
+echo "GitHub Package Registry login..."
+docker login docker.pkg.github.com -u $GITHUB_REGISTRY_USER --password-stdin <<< $GITHUB_REGISTRY_TOKEN &&
+echo "Tagging..." &&
+docker tag greenpi-backend:$VERSION docker.pkg.github.com/gabrielmdc/greenpi-backend/greenpi-backend:$VERSION
+echo "Pushing image into GitHub Package Registry..." &&
+docker push docker.pkg.github.com/gabrielmdc/greenpi-backend/greenpi-backend:$VERSION


### PR DESCRIPTION
Now it is possible to deploy a Docker image into GitHub Package Registry.

The image is also in DockerHub: https://cloud.docker.com/u/gmdcwork/repository/docker/gmdcwork/greenpi-backend

Fixes #152 