### PR TITLE
fix: package version number (1.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenpi-backend",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "description": "Save measures and configuration of greenPi project",
   "main": "dist/src/index.js",
   "scripts": {


### PR DESCRIPTION
Since https://github.com/gabrielmdc/greenpi-backend/pull/161 the package version number should be 1.0.0