### PR TITLE
chore: git ignore .vscode/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.js
 *.js.map
 nodemon.json
+.vscode/launch.json


### PR DESCRIPTION
This file is used for vscode debuggin.
To debug in vscode:
- Create .vscode/launch.json
- Add data: _(exampe)_
```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "Launch Program",
      "program": "${workspaceFolder}/src/index.ts",
      "preLaunchTask": "tsc: build - tsconfig.json",
      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
      "env": {
        "DATABASE_URI": "mongodb://dev_uri",
        "GOOGLE_CLIENT_ID": "XXX",
        "GOOGLE_CLIENT_SECRET": "XXX",
        "GOOGLE_REDIR_URL": "http://localhost:8000/sign-in/google",
        "SECURITY_JWT_SECRET": "s0me-Random_Secr3t"
      }
    }
  ]
}
```
I advise to copy the env variables from _nodemon.json_